### PR TITLE
Disable Merlin WP

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -769,3 +769,8 @@ require get_parent_theme_file_path( '/inc/admin/init.php' );
  * Disable Dashboard Doc.
  */
 function themebeans_guide() {}
+
+/**
+ * Disable Merlin WP.
+ */
+function themebeans_merlin() {}


### PR DESCRIPTION
The sandbox servers are no longer available, which is where the demo content is pulled from. Eventually we could remap where the demo content is coming from.